### PR TITLE
refactor: enhance migration scripts for conditional table and column …

### DIFF
--- a/src/migrations/20250421_201656.json
+++ b/src/migrations/20250421_201656.json
@@ -381,12 +381,8 @@
           "name": "exercises_icon_id_media_id_fk",
           "tableFrom": "exercises",
           "tableTo": "media",
-          "columnsFrom": [
-            "icon_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["icon_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -536,12 +532,8 @@
           "name": "versions_exercise_id_exercises_id_fk",
           "tableFrom": "versions",
           "tableTo": "exercises",
-          "columnsFrom": [
-            "exercise_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["exercise_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -653,12 +645,8 @@
           "name": "days_version_id_versions_id_fk",
           "tableFrom": "days",
           "tableTo": "versions",
-          "columnsFrom": [
-            "version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -741,12 +729,8 @@
           "name": "tasks_tasks_parent_id_fk",
           "tableFrom": "tasks_tasks",
           "tableTo": "tasks",
-          "columnsFrom": [
-            "_parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["_parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -885,12 +869,8 @@
           "name": "tasks_version_id_versions_id_fk",
           "tableFrom": "tasks",
           "tableTo": "versions",
-          "columnsFrom": [
-            "version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1002,12 +982,8 @@
           "name": "weekly_meeting_version_id_versions_id_fk",
           "tableFrom": "weekly_meeting",
           "tableTo": "versions",
-          "columnsFrom": [
-            "version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1176,12 +1152,8 @@
           "name": "guide_version_id_versions_id_fk",
           "tableFrom": "guide",
           "tableTo": "versions",
-          "columnsFrom": [
-            "version_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1189,12 +1161,8 @@
           "name": "guide_author_id_users_id_fk",
           "tableFrom": "guide",
           "tableTo": "users",
-          "columnsFrom": [
-            "author_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1539,12 +1507,8 @@
           "name": "payload_locked_documents_rels_parent_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "payload_locked_documents",
-          "columnsFrom": [
-            "parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1552,12 +1516,8 @@
           "name": "payload_locked_documents_rels_users_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "users",
-          "columnsFrom": [
-            "users_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1565,12 +1525,8 @@
           "name": "payload_locked_documents_rels_media_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "media",
-          "columnsFrom": [
-            "media_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1578,12 +1534,8 @@
           "name": "payload_locked_documents_rels_exercises_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "exercises",
-          "columnsFrom": [
-            "exercises_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["exercises_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1591,12 +1543,8 @@
           "name": "payload_locked_documents_rels_versions_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "versions",
-          "columnsFrom": [
-            "versions_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["versions_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1604,12 +1552,8 @@
           "name": "payload_locked_documents_rels_days_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "days",
-          "columnsFrom": [
-            "days_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["days_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1617,12 +1561,8 @@
           "name": "payload_locked_documents_rels_tasks_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "tasks",
-          "columnsFrom": [
-            "tasks_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["tasks_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1630,12 +1570,8 @@
           "name": "payload_locked_documents_rels_weekly_meeting_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "weekly_meeting",
-          "columnsFrom": [
-            "weekly_meeting_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["weekly_meeting_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1643,12 +1579,8 @@
           "name": "payload_locked_documents_rels_guide_fk",
           "tableFrom": "payload_locked_documents_rels",
           "tableTo": "guide",
-          "columnsFrom": [
-            "guide_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["guide_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1852,12 +1784,8 @@
           "name": "payload_preferences_rels_parent_fk",
           "tableFrom": "payload_preferences_rels",
           "tableTo": "payload_preferences",
-          "columnsFrom": [
-            "parent_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1865,12 +1793,8 @@
           "name": "payload_preferences_rels_users_fk",
           "tableFrom": "payload_preferences_rels",
           "tableTo": "users",
-          "columnsFrom": [
-            "users_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["users_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1962,26 +1886,12 @@
     "public.enum_tasks_type": {
       "name": "enum_tasks_type",
       "schema": "public",
-      "values": [
-        "daily",
-        "weekly",
-        "weekday",
-        "monthly",
-        "specificDay"
-      ]
+      "values": ["daily", "weekly", "weekday", "monthly", "specificDay"]
     },
     "public.enum_tasks_scheduling_day_in_week": {
       "name": "enum_tasks_scheduling_day_in_week",
       "schema": "public",
-      "values": [
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7"
-      ]
+      "values": ["1", "2", "3", "4", "5", "6", "7"]
     }
   },
   "schemas": {},

--- a/src/migrations/20250421_201657.ts
+++ b/src/migrations/20250421_201657.ts
@@ -1,0 +1,20 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from "@payloadcms/db-postgres";
+
+export async function up({ db, payload, req }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+    -- Set default values for existing rows
+    UPDATE "versions"
+    SET 
+      "start_date" = now(),
+      "end_date" = now() + interval '90 days',
+      "duration" = 90
+    WHERE "start_date" IS NULL 
+    OR "end_date" IS NULL 
+    OR "duration" IS NULL;
+  `);
+}
+
+export async function down({ db, payload, req }: MigrateDownArgs): Promise<void> {
+  // No down migration needed as we don't want to remove the data
+  await db.execute(sql`SELECT 1;`);
+}


### PR DESCRIPTION
…management

- Updated migration logic to conditionally drop the "starting_dates" table and its constraints if they exist.
- Added checks to ensure new columns ("start_date", "end_date", "duration", "guide_id") are only added if they do not already exist in the "versions" and "payload_locked_documents_rels" tables.
- Introduced a new migration file (20250421_201657.ts) to set default values for the new columns in the "versions" table.